### PR TITLE
feat(api): migrate items to drizzle and chanfana

### DIFF
--- a/docs/superpowers/SESSION_STATE.md
+++ b/docs/superpowers/SESSION_STATE.md
@@ -1,0 +1,98 @@
+# Session State — cloudfire-apiv1 v2 upgrade
+
+**Last updated:** 2026-05-01  
+**Status:** Plan completo, listo para ejecutar. Tasks 1-5 del PR1 NO iniciadas aún.
+
+---
+
+## Qué se hizo en esta sesión
+
+1. **Análisis del proyecto** — API Hono + D1 + TypeScript, raw SQL, API Key auth
+2. **Seguridad** — API key `e181e2503f5f...` en `.claude/settings.local.json` es real y funciona en prod. Rotar con `wrangler secret put API_KEY`. Archivo NO está en GitHub (.gitignore lo excluye).
+3. **Diseño aprobado** — spec en `docs/superpowers/specs/2026-05-01-apiv1-v2-clean-code-design.md`
+4. **Plan completo escrito** — `docs/superpowers/plans/2026-05-01-apiv1-v2-clean-code.md`
+5. **Ambos commiteados y pusheados a main**
+
+---
+
+## Stack nuevo (a implementar)
+
+| Capa | Antes | Después |
+|---|---|---|
+| Framework | Hono | Hono + Chanfana (OpenAPIHono) |
+| DB access | Raw SQL D1 | Drizzle ORM (drizzle-orm/d1) |
+| Validación | if manuales | Zod v4 |
+| Docs | Ninguna | OpenAPI 3.1 en /docs (Chanfana) |
+| Tests mock | Regex in-memory | better-sqlite3 real SQLite |
+
+---
+
+## Arquitectura Clean Code
+
+```
+src/
+├── db/schema.ts              ← Drizzle tables
+├── db/index.ts               ← createDb() factory
+├── schemas/*.schema.ts       ← Zod v4 shapes
+├── repositories/*.repository.ts  ← Drizzle queries
+├── services/orders.service.ts    ← solo orders tiene lógica
+├── routes/*.ts               ← Chanfana OpenAPIRoute handlers
+├── middleware/apiKey.ts      ← sin cambios
+└── index.ts                  ← OpenAPIHono mount
+```
+
+---
+
+## Modelo de datos
+
+```
+categories  id, name, description, created_at
+users       id, name, email(unique), created_at
+items       id, name, description, price, category_id→categories, created_at
+orders      id, user_id→users, status(pending|confirmed|shipped|delivered), total, created_at
+order_items id, order_id→orders, item_id→items, quantity, unit_price(snapshot)
+```
+
+---
+
+## PRs pendientes (flujo GitHub)
+
+| # | Task | Branch | Estado |
+|---|---|---|---|
+| PR1-a | GitHub issue + deps + Drizzle schema + migration + types | `feat/infra-drizzle-chanfana` | **PENDIENTE** |
+| PR1-b | Items schema + repo + route + index.ts + d1-mock + tests + PR | `feat/infra-drizzle-chanfana` | **PENDIENTE** |
+| PR2 | Categories resource completo + PR | `feat/categories` | **PENDIENTE** (espera PR1) |
+| PR3 | Users resource completo + PR | `feat/users` | **PENDIENTE** (espera PR1) |
+| PR4 | Orders resource + service + PR | `feat/orders` | **PENDIENTE** (espera PR1+PR3) |
+
+---
+
+## Cómo retomar en nueva sesión
+
+1. Leer este archivo
+2. Leer el plan completo: `docs/superpowers/plans/2026-05-01-apiv1-v2-clean-code.md`
+3. Verificar estado del repo: `git branch -a` y `git status`
+4. Si estamos en `main` sin cambios → empezar por Task 1 del PR1
+5. Ejecutar con: invocar skill `superpowers:subagent-driven-development`
+6. Tests corren via Docker: `docker compose --profile test run --rm test`
+7. NUNCA correr `npm install` en el host — solo dentro de Docker
+
+---
+
+## Archivos clave
+
+- Plan: `docs/superpowers/plans/2026-05-01-apiv1-v2-clean-code.md`
+- Spec: `docs/superpowers/specs/2026-05-01-apiv1-v2-clean-code-design.md`
+- Estado actual: `docs/superpowers/SESSION_STATE.md` (este archivo)
+- API en prod: `https://cloudfire-apiv1.wrcp20.workers.dev`
+- Repo GitHub: `https://github.com/wrcp20/cloudfire-apiv1`
+
+---
+
+## Tasks del sistema (IDs)
+
+- Task #1 — PR1-a (infra): in_progress
+- Task #2 — PR1-b (items layer): blocked por #1
+- Task #3 — PR2 (categories): blocked por #1, #2
+- Task #4 — PR3 (users): blocked por #1, #2
+- Task #5 — PR4 (orders): blocked por #1, #2, #4

--- a/docs/superpowers/SESSION_STATE.md
+++ b/docs/superpowers/SESSION_STATE.md
@@ -1,7 +1,7 @@
 # Session State — cloudfire-apiv1 v2 upgrade
 
 **Last updated:** 2026-05-01  
-**Status:** Plan completo, listo para ejecutar. Tasks 1-5 del PR1 NO iniciadas aún.
+**Status:** PR1-a y PR1-b completados localmente en `feat/infra-drizzle-chanfana`. PR2-PR4 siguen pendientes.
 
 ---
 
@@ -12,6 +12,8 @@
 3. **Diseño aprobado** — spec en `docs/superpowers/specs/2026-05-01-apiv1-v2-clean-code-design.md`
 4. **Plan completo escrito** — `docs/superpowers/plans/2026-05-01-apiv1-v2-clean-code.md`
 5. **Ambos commiteados y pusheados a main**
+6. **PR1-a ejecutado localmente** — issue `#12` creado y agregado al project board, branch `feat/infra-drizzle-chanfana` activa, deps v2 agregadas, `src/db/{schema.ts,index.ts}` creados, `migrations/0002_v2_schema.sql` creado y `src/types.ts` migrado
+7. **PR1-b ejecutado localmente** — `items` migrado a Zod + Drizzle + Chanfana (`src/schemas/items.schema.ts`, `src/repositories/items.repository.ts`, `src/routes/items.ts`, `src/index.ts`), mock D1 reemplazado por SQLite real en memoria con `better-sqlite3`, tests ampliados a 26 casos
 
 ---
 
@@ -59,8 +61,8 @@ order_items id, order_id→orders, item_id→items, quantity, unit_price(snapsho
 
 | # | Task | Branch | Estado |
 |---|---|---|---|
-| PR1-a | GitHub issue + deps + Drizzle schema + migration + types | `feat/infra-drizzle-chanfana` | **PENDIENTE** |
-| PR1-b | Items schema + repo + route + index.ts + d1-mock + tests + PR | `feat/infra-drizzle-chanfana` | **PENDIENTE** |
+| PR1-a | GitHub issue + deps + Drizzle schema + migration + types | `feat/infra-drizzle-chanfana` | **COMPLETADO LOCAL** |
+| PR1-b | Items schema + repo + route + index.ts + d1-mock + tests + PR | `feat/infra-drizzle-chanfana` | **COMPLETADO LOCAL** |
 | PR2 | Categories resource completo + PR | `feat/categories` | **PENDIENTE** (espera PR1) |
 | PR3 | Users resource completo + PR | `feat/users` | **PENDIENTE** (espera PR1) |
 | PR4 | Orders resource + service + PR | `feat/orders` | **PENDIENTE** (espera PR1+PR3) |
@@ -72,10 +74,11 @@ order_items id, order_id→orders, item_id→items, quantity, unit_price(snapsho
 1. Leer este archivo
 2. Leer el plan completo: `docs/superpowers/plans/2026-05-01-apiv1-v2-clean-code.md`
 3. Verificar estado del repo: `git branch -a` y `git status`
-4. Si estamos en `main` sin cambios → empezar por Task 1 del PR1
+4. Hacer commit/push/PR de `feat/infra-drizzle-chanfana` o continuar con PR2 desde una branch nueva cuando se cierre PR1
 5. Ejecutar con: invocar skill `superpowers:subagent-driven-development`
 6. Tests corren via Docker: `docker compose --profile test run --rm test`
 7. NUNCA correr `npm install` en el host — solo dentro de Docker
+8. `docker compose --profile test run --rm test npm run typecheck`, `npm test` y `npm run lint` pasan; lint deja warnings por casts de compatibilidad en Chanfana
 
 ---
 
@@ -91,8 +94,8 @@ order_items id, order_id→orders, item_id→items, quantity, unit_price(snapsho
 
 ## Tasks del sistema (IDs)
 
-- Task #1 — PR1-a (infra): in_progress
-- Task #2 — PR1-b (items layer): blocked por #1
+- Task #1 — PR1-a (infra): completed locally
+- Task #2 — PR1-b (items layer): completed locally
 - Task #3 — PR2 (categories): blocked por #1, #2
 - Task #4 — PR3 (users): blocked por #1, #2
 - Task #5 — PR4 (orders): blocked por #1, #2, #4

--- a/migrations/0002_v2_schema.sql
+++ b/migrations/0002_v2_schema.sql
@@ -1,0 +1,31 @@
+ALTER TABLE items ADD COLUMN category_id INTEGER REFERENCES categories(id);
+
+CREATE TABLE IF NOT EXISTS categories (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  name TEXT NOT NULL,
+  description TEXT,
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE TABLE IF NOT EXISTS users (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  name TEXT NOT NULL,
+  email TEXT NOT NULL UNIQUE,
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE TABLE IF NOT EXISTS orders (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  user_id INTEGER NOT NULL REFERENCES users(id),
+  status TEXT NOT NULL DEFAULT 'pending',
+  total REAL NOT NULL DEFAULT 0,
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE TABLE IF NOT EXISTS order_items (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  order_id INTEGER NOT NULL REFERENCES orders(id),
+  item_id INTEGER NOT NULL REFERENCES items(id),
+  quantity INTEGER NOT NULL,
+  unit_price REAL NOT NULL
+);

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,11 +8,16 @@
       "name": "cloudfire-apiv1",
       "version": "1.0.0",
       "dependencies": {
-        "hono": "^4.7.10"
+        "chanfana": "^2.4.3",
+        "drizzle-orm": "^0.43.1",
+        "hono": "^4.7.10",
+        "zod": "^4.0.0"
       },
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20250430.0",
         "@eslint/js": "^9.26.0",
+        "@types/better-sqlite3": "^7.6.13",
+        "better-sqlite3": "^11.10.0",
         "eslint": "^9.26.0",
         "typescript": "^5.8.3",
         "typescript-eslint": "^8.32.0",
@@ -135,7 +140,7 @@
       "version": "4.20260430.1",
       "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260430.1.tgz",
       "integrity": "sha512-Rguf/SdQNm1HG2yZi8m57K4qvVh2fic+Xny4UidY1pCgHagOAq7Cy0WIp1JKQx54T8lgOgOWFzIaCK4iwLpxlg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT OR Apache-2.0"
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -1715,6 +1720,16 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/better-sqlite3": {
+      "version": "7.6.13",
+      "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
+      "integrity": "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/chai": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
@@ -1746,6 +1761,16 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.19.0"
+      }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.59.1",
@@ -2182,7 +2207,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/assertion-error": {
@@ -2202,6 +2226,61 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "devOptional": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/better-sqlite3": {
+      "version": "11.10.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-11.10.0.tgz",
+      "integrity": "sha512-EwhOpyXiOEL/lKzHz9AW1msWFNzGc/z+LzeB3/jnFJpxu+th2yqvzsSWas1v9jgs9+xiXJcD5A8CJxAG2TaghQ==",
+      "devOptional": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
     "node_modules/blake3-wasm": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
@@ -2218,6 +2297,31 @@
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "devOptional": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "node_modules/callsites": {
@@ -2269,6 +2373,50 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/chanfana": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/chanfana/-/chanfana-2.8.3.tgz",
+      "integrity": "sha512-OBefbT8n+CeRYkC6lUoRgySTFbth+3LetxiNrCe0t+WgpQhhoIxPlo+lDYvNrLJgtsQr7XuPazm8yyxR8zwB7g==",
+      "license": "MIT",
+      "dependencies": {
+        "@asteasolutions/zod-to-openapi": "^7.2.0",
+        "js-yaml": "^4.1.0",
+        "openapi3-ts": "^4.4.0",
+        "yargs-parser": "^22.0.0",
+        "zod": "^3.23.8"
+      },
+      "bin": {
+        "chanfana": "dist/cli.js"
+      }
+    },
+    "node_modules/chanfana/node_modules/@asteasolutions/zod-to-openapi": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@asteasolutions/zod-to-openapi/-/zod-to-openapi-7.3.4.tgz",
+      "integrity": "sha512-/2rThQ5zPi9OzVwes6U7lK1+Yvug0iXu25olp7S0XsYmOqnyMfxH7gdSQjn/+DSOHRg7wnotwGJSyL+fBKdnEA==",
+      "license": "MIT",
+      "dependencies": {
+        "openapi3-ts": "^4.1.2"
+      },
+      "peerDependencies": {
+        "zod": "^3.20.2"
+      }
+    },
+    "node_modules/chanfana/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "devOptional": true,
+      "license": "ISC"
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
@@ -2351,6 +2499,32 @@
         }
       }
     },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -2362,10 +2536,141 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/drizzle-orm": {
+      "version": "0.43.1",
+      "resolved": "https://registry.npmjs.org/drizzle-orm/-/drizzle-orm-0.43.1.tgz",
+      "integrity": "sha512-dUcDaZtE/zN4RV/xqGrVSMpnEczxd5cIaoDeor7Zst9wOe/HzC/7eAaulywWGYXdDEc9oBPMjayVEDg0ziTLJA==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@aws-sdk/client-rds-data": ">=3",
+        "@cloudflare/workers-types": ">=4",
+        "@electric-sql/pglite": ">=0.2.0",
+        "@libsql/client": ">=0.10.0",
+        "@libsql/client-wasm": ">=0.10.0",
+        "@neondatabase/serverless": ">=0.10.0",
+        "@op-engineering/op-sqlite": ">=2",
+        "@opentelemetry/api": "^1.4.1",
+        "@planetscale/database": ">=1.13",
+        "@prisma/client": "*",
+        "@tidbcloud/serverless": "*",
+        "@types/better-sqlite3": "*",
+        "@types/pg": "*",
+        "@types/sql.js": "*",
+        "@vercel/postgres": ">=0.8.0",
+        "@xata.io/client": "*",
+        "better-sqlite3": ">=7",
+        "bun-types": "*",
+        "expo-sqlite": ">=14.0.0",
+        "gel": ">=2",
+        "knex": "*",
+        "kysely": "*",
+        "mysql2": ">=2",
+        "pg": ">=8",
+        "postgres": ">=3",
+        "sql.js": ">=1",
+        "sqlite3": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/client-rds-data": {
+          "optional": true
+        },
+        "@cloudflare/workers-types": {
+          "optional": true
+        },
+        "@electric-sql/pglite": {
+          "optional": true
+        },
+        "@libsql/client": {
+          "optional": true
+        },
+        "@libsql/client-wasm": {
+          "optional": true
+        },
+        "@neondatabase/serverless": {
+          "optional": true
+        },
+        "@op-engineering/op-sqlite": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@planetscale/database": {
+          "optional": true
+        },
+        "@prisma/client": {
+          "optional": true
+        },
+        "@tidbcloud/serverless": {
+          "optional": true
+        },
+        "@types/better-sqlite3": {
+          "optional": true
+        },
+        "@types/pg": {
+          "optional": true
+        },
+        "@types/sql.js": {
+          "optional": true
+        },
+        "@vercel/postgres": {
+          "optional": true
+        },
+        "@xata.io/client": {
+          "optional": true
+        },
+        "better-sqlite3": {
+          "optional": true
+        },
+        "bun-types": {
+          "optional": true
+        },
+        "expo-sqlite": {
+          "optional": true
+        },
+        "gel": {
+          "optional": true
+        },
+        "knex": {
+          "optional": true
+        },
+        "kysely": {
+          "optional": true
+        },
+        "mysql2": {
+          "optional": true
+        },
+        "pg": {
+          "optional": true
+        },
+        "postgres": {
+          "optional": true
+        },
+        "prisma": {
+          "optional": true
+        },
+        "sql.js": {
+          "optional": true
+        },
+        "sqlite3": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
       }
     },
     "node_modules/error-stack-parser-es": {
@@ -2604,6 +2909,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "devOptional": true,
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -2666,6 +2981,13 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "devOptional": true,
+      "license": "MIT"
+    },
     "node_modules/find-up": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -2704,6 +3026,13 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "devOptional": true,
+      "license": "MIT"
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -2718,6 +3047,13 @@
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/glob-parent": {
       "version": "6.0.2",
@@ -2764,6 +3100,27 @@
         "node": ">=16.9.0"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "devOptional": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -2801,6 +3158,20 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "devOptional": true,
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "devOptional": true,
+      "license": "ISC"
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -2835,7 +3206,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
       "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -3193,6 +3563,19 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/miniflare": {
       "version": "4.20260430.0",
       "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260430.0.tgz",
@@ -3227,6 +3610,23 @@
         "node": "*"
       }
     },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "devOptional": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "devOptional": true,
+      "license": "MIT"
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -3253,12 +3653,32 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "devOptional": true,
+      "license": "MIT"
+    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/node-abi": {
+      "version": "3.90.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.90.0.tgz",
+      "integrity": "sha512-pZNQT7UnYlMwMBy5N1lV5X/YLTbZM5ncytN3xL7CHEzhDN8uVe0u55yaPUJICIJjaCW8NrM5BFdqr7HLweStNA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/obug": {
       "version": "2.1.1",
@@ -3270,6 +3690,25 @@
         "https://opencollective.com/debug"
       ],
       "license": "MIT"
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "devOptional": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/openapi3-ts": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/openapi3-ts/-/openapi3-ts-4.5.0.tgz",
+      "integrity": "sha512-jaL+HgTq2Gj5jRcfdutgRGLosCy/hT8sQf6VOy+P+g36cZOjI1iukdPnijC+4CmeRzg/jEllJUboEic2FhxhtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "yaml": "^2.8.0"
+      }
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -3417,6 +3856,34 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -3427,6 +3894,17 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -3435,6 +3913,47 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "devOptional": true,
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/rc/node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/resolve-from": {
@@ -3481,11 +4000,32 @@
         "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "devOptional": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/semver": {
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -3569,6 +4109,53 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "devOptional": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "devOptional": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -3592,6 +4179,16 @@
       "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
     },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
@@ -3617,6 +4214,36 @@
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/tinybench": {
@@ -3673,6 +4300,19 @@
       "dev": true,
       "license": "0BSD",
       "optional": true
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -3735,6 +4375,13 @@
         "node": ">=20.18.1"
       }
     },
+    "node_modules/undici-types": {
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "devOptional": true,
+      "license": "MIT"
+    },
     "node_modules/unenv": {
       "version": "2.0.0-rc.24",
       "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.24.tgz",
@@ -3754,6 +4401,13 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/vite": {
       "version": "8.0.10",
@@ -4090,6 +4744,13 @@
         }
       }
     },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "devOptional": true,
+      "license": "ISC"
+    },
     "node_modules/ws": {
       "version": "8.18.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
@@ -4110,6 +4771,30 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
       }
     },
     "node_modules/yocto-queue": {
@@ -4148,6 +4833,15 @@
       "dependencies": {
         "@poppinss/exception": "^1.2.2",
         "error-stack-parser-es": "^1.0.5"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.2.tgz",
+      "integrity": "sha512-IynmDyxsEsb9RKzO3J9+4SxXnl2FTFSzNBaKKaMV6tsSk0rw9gYw9gs+JFCq/qk2LCZ78KDwyj+Z289TijSkUw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20250430.0",
     "@eslint/js": "^9.26.0",
+    "@types/better-sqlite3": "^7.6.13",
+    "better-sqlite3": "^11.10.0",
     "eslint": "^9.26.0",
     "typescript": "^5.8.3",
     "typescript-eslint": "^8.32.0",
@@ -24,6 +26,9 @@
     "wrangler": "^4.86.0"
   },
   "dependencies": {
-    "hono": "^4.7.10"
+    "chanfana": "^2.4.3",
+    "drizzle-orm": "^0.43.1",
+    "hono": "^4.7.10",
+    "zod": "^4.0.0"
   }
 }

--- a/src/__tests__/helpers/d1-mock.ts
+++ b/src/__tests__/helpers/d1-mock.ts
@@ -1,67 +1,71 @@
+import BetterSqlite3 from 'better-sqlite3'
 import type { D1Database } from '@cloudflare/workers-types'
-import type { Item } from '../../types'
 
-type Row = Item
+export const SCHEMA = `
+  CREATE TABLE IF NOT EXISTS categories (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL,
+    description TEXT,
+    created_at TEXT NOT NULL DEFAULT (datetime('now'))
+  );
+  CREATE TABLE IF NOT EXISTS users (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL,
+    email TEXT NOT NULL UNIQUE,
+    created_at TEXT NOT NULL DEFAULT (datetime('now'))
+  );
+  CREATE TABLE IF NOT EXISTS items (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL,
+    description TEXT,
+    price REAL NOT NULL DEFAULT 0,
+    category_id INTEGER REFERENCES categories(id),
+    created_at TEXT NOT NULL DEFAULT (datetime('now'))
+  );
+  CREATE TABLE IF NOT EXISTS orders (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id INTEGER NOT NULL REFERENCES users(id),
+    status TEXT NOT NULL DEFAULT 'pending',
+    total REAL NOT NULL DEFAULT 0,
+    created_at TEXT NOT NULL DEFAULT (datetime('now'))
+  );
+  CREATE TABLE IF NOT EXISTS order_items (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    order_id INTEGER NOT NULL REFERENCES orders(id),
+    item_id INTEGER NOT NULL REFERENCES items(id),
+    quantity INTEGER NOT NULL,
+    unit_price REAL NOT NULL
+  );
+`
 
-export function createTestDb(): D1Database {
-  const rows: Row[] = []
-  let nextId = 1
+export function createTestDb(schema: string = SCHEMA): D1Database {
+  const sqlite = new BetterSqlite3(':memory:')
+  sqlite.exec(schema)
 
-  function now() {
-    return new Date().toISOString().replace('T', ' ').slice(0, 19)
+  function makeStmt(query: string, args: unknown[] = []) {
+    const stmt = sqlite.prepare(query)
+    const rawStmt = sqlite.prepare(query).raw(true)
+
+    return {
+      all: <T>() => Promise.resolve({ results: stmt.all(...args) as T[] }),
+      first: <T>() => Promise.resolve((stmt.get(...args) ?? null) as T | null),
+      run: () => {
+        stmt.run(...args)
+        return Promise.resolve({ success: true as const, results: [], meta: {} as D1Meta })
+      },
+      raw: <T>() => Promise.resolve(rawStmt.all(...args) as T[]),
+    }
   }
-
-  function run(query: string, args: unknown[]): { results: Row[]; single: Row | null } {
-    const q = query.trim().replace(/\s+/g, ' ')
-
-    if (/^SELECT \* FROM items ORDER BY/.test(q)) {
-      return { results: [...rows].reverse(), single: null }
-    }
-
-    if (/^SELECT (\*|id) FROM items WHERE id = \?/.test(q)) {
-      const found = rows.find(r => r.id === Number(args[0])) ?? null
-      return { results: found ? [found] : [], single: found }
-    }
-
-    if (/^INSERT INTO items/.test(q)) {
-      const [name, description, price] = args as [string, string | null, number]
-      const row: Row = { id: nextId++, name, description: description ?? null, price, created_at: now() }
-      rows.push(row)
-      return { results: [row], single: row }
-    }
-
-    if (/^UPDATE items SET/.test(q)) {
-      const [name, description, price, id] = args as [string, string | null, number, number]
-      const row = rows.find(r => r.id === id) ?? null
-      if (row) { row.name = name; row.description = description ?? null; row.price = price }
-      return { results: row ? [row] : [], single: row }
-    }
-
-    if (/^DELETE FROM items WHERE id = \?/.test(q)) {
-      const idx = rows.findIndex(r => r.id === Number(args[0]))
-      if (idx !== -1) rows.splice(idx, 1)
-      return { results: [], single: null }
-    }
-
-    return { results: [], single: null }
-  }
-
-  const makeBound = (query: string, args: unknown[]) => ({
-    all: <T>() => Promise.resolve({ results: run(query, args).results as unknown as T[] }),
-    first: <T>() => Promise.resolve(run(query, args).single as unknown as T | null),
-    run: () => { run(query, args); return Promise.resolve({ success: true as const, results: [], meta: {} as D1Meta }) },
-    raw: <T>() => Promise.resolve([] as T[]),
-  })
 
   return {
     prepare: (query: string) => ({
-      bind: (...args: unknown[]) => makeBound(query, args),
-      all: <T>() => Promise.resolve({ results: run(query, []).results as unknown as T[] }),
-      first: <T>() => Promise.resolve(run(query, []).single as unknown as T | null),
-      run: () => Promise.resolve({ success: true as const, results: [], meta: {} as D1Meta }),
-      raw: <T>() => Promise.resolve([] as T[]),
+      ...makeStmt(query),
+      bind: (...args: unknown[]) => makeStmt(query, args),
     }),
-    exec: (_q: string) => Promise.resolve({ count: 0, duration: 0 }),
+    exec: (query: string) => {
+      sqlite.exec(query)
+      return Promise.resolve({ count: 0, duration: 0 })
+    },
     batch: async () => [],
     dump: async () => new ArrayBuffer(0),
   } as unknown as D1Database

--- a/src/__tests__/items.test.ts
+++ b/src/__tests__/items.test.ts
@@ -28,23 +28,31 @@ const put = (path: string, body: unknown) => req('PUT', path, { body, key: TEST_
 const del = (path: string) => req('DELETE', path, { key: TEST_API_KEY })
 
 describe('GET /', () => {
-  it('devuelve health check', async () => {
+  it('devuelve health check con version 2.0.0', async () => {
     const res = await get('/')
     expect(res.status).toBe(200)
     const body = await res.json() as Record<string, unknown>
     expect(body.status).toBe('ok')
+    expect(body.version).toBe('2.0.0')
+    expect(body.name).toBe('cloudfire-apiv1')
   })
 })
 
 describe('Auth middleware', () => {
   it('POST sin API key devuelve 401', async () => {
-    const res = await post('/items', { name: 'Test', price: 10 })
-    expect(res.status).toBe(401)
+    expect((await post('/items', { name: 'Test', price: 10 })).status).toBe(401)
   })
 
   it('POST con API key incorrecta devuelve 401', async () => {
-    const res = await post('/items', { name: 'Test', price: 10 }, 'clave-falsa')
-    expect(res.status).toBe(401)
+    expect((await post('/items', { name: 'Test', price: 10 }, 'clave-falsa')).status).toBe(401)
+  })
+
+  it('PUT sin API key devuelve 401', async () => {
+    expect((await req('PUT', '/items/1', { body: { price: 5 } })).status).toBe(401)
+  })
+
+  it('DELETE sin API key devuelve 401', async () => {
+    expect((await req('DELETE', '/items/1')).status).toBe(401)
   })
 })
 
@@ -56,6 +64,14 @@ describe('GET /items', () => {
     expect(body.data).toEqual([])
     expect(body.count).toBe(0)
   })
+
+  it('count coincide con cantidad de items creados', async () => {
+    await post('/items', { name: 'A', price: 1 }, TEST_API_KEY)
+    await post('/items', { name: 'B', price: 2 }, TEST_API_KEY)
+    const body = await get('/items').then((response: Response) => response.json()) as { data: unknown[]; count: number }
+    expect(body.count).toBe(2)
+    expect(body.data).toHaveLength(2)
+  })
 })
 
 describe('POST /items', () => {
@@ -65,6 +81,14 @@ describe('POST /items', () => {
     const body = await res.json() as { data: { name: string; price: number } }
     expect(body.data.name).toBe('Laptop')
     expect(body.data.price).toBe(999.99)
+  })
+
+  it('price = 0 es válido', async () => {
+    expect((await post('/items', { name: 'Free', price: 0 }, TEST_API_KEY)).status).toBe(201)
+  })
+
+  it('price = 999999 es válido', async () => {
+    expect((await post('/items', { name: 'Caro', price: 999_999 }, TEST_API_KEY)).status).toBe(201)
   })
 
   it('devuelve 422 si falta name', async () => {
@@ -81,6 +105,18 @@ describe('POST /items', () => {
     const res = await post('/items', { name: 'Test', price: -1 }, TEST_API_KEY)
     expect(res.status).toBe(422)
   })
+
+  it('devuelve 422 si price supera 999999', async () => {
+    expect((await post('/items', { name: 'Test', price: 1_000_000 }, TEST_API_KEY)).status).toBe(422)
+  })
+
+  it('devuelve 422 si name es solo espacios', async () => {
+    expect((await post('/items', { name: '   ', price: 10 }, TEST_API_KEY)).status).toBe(422)
+  })
+
+  it('devuelve 422 si description supera 1000 caracteres', async () => {
+    expect((await post('/items', { name: 'Test', price: 10, description: 'X'.repeat(1001) }, TEST_API_KEY)).status).toBe(422)
+  })
 })
 
 describe('GET /items/:id', () => {
@@ -89,13 +125,19 @@ describe('GET /items/:id', () => {
     expect(res.status).toBe(404)
   })
 
+  it('devuelve 400 si el ID no es numérico', async () => {
+    expect((await get('/items/abc')).status).toBe(400)
+  })
+
   it('devuelve el item si existe', async () => {
     await post('/items', { name: 'Monitor', price: 300 }, TEST_API_KEY)
     const list = await get('/items').then((r: Response) => r.json()) as { data: Array<{ id: number }> }
-    const id = list.data[0]?.id
+    const id = list.data[0]!.id
 
     const res = await get(`/items/${id}`)
     expect(res.status).toBe(200)
+    const body = await res.json() as { data: { name: string } }
+    expect(body.data.name).toBe('Monitor')
   })
 })
 
@@ -103,12 +145,31 @@ describe('PUT /items/:id', () => {
   it('actualiza el precio de un item', async () => {
     await post('/items', { name: 'Teclado', price: 80 }, TEST_API_KEY)
     const list = await get('/items').then((r: Response) => r.json()) as { data: Array<{ id: number }> }
-    const id = list.data[0]?.id
+    const id = list.data[0]!.id
 
     const res = await put(`/items/${id}`, { price: 65 })
     expect(res.status).toBe(200)
     const body = await res.json() as { data: { price: number } }
     expect(body.data.price).toBe(65)
+  })
+
+  it('actualiza el nombre de un item', async () => {
+    await post('/items', { name: 'Viejo', price: 50 }, TEST_API_KEY)
+    const list = await get('/items').then((r: Response) => r.json()) as { data: Array<{ id: number }> }
+    const id = list.data[0]!.id
+
+    const res = await put(`/items/${id}`, { name: 'Nuevo' })
+    expect(res.status).toBe(200)
+    const body = await res.json() as { data: { name: string } }
+    expect(body.data.name).toBe('Nuevo')
+  })
+
+  it('devuelve 404 si el item no existe', async () => {
+    expect((await put('/items/999', { price: 10 })).status).toBe(404)
+  })
+
+  it('devuelve 400 si el ID no es numérico', async () => {
+    expect((await req('PUT', '/items/abc', { body: { price: 10 }, key: TEST_API_KEY })).status).toBe(400)
   })
 })
 
@@ -116,9 +177,17 @@ describe('DELETE /items/:id', () => {
   it('elimina un item existente y confirma con 404', async () => {
     await post('/items', { name: 'Mouse', price: 30 }, TEST_API_KEY)
     const list = await get('/items').then((r: Response) => r.json()) as { data: Array<{ id: number }> }
-    const id = list.data[0]?.id
+    const id = list.data[0]!.id
 
     expect((await del(`/items/${id}`)).status).toBe(200)
     expect((await get(`/items/${id}`)).status).toBe(404)
+  })
+
+  it('devuelve 404 si el item no existe', async () => {
+    expect((await del('/items/999')).status).toBe(404)
+  })
+
+  it('devuelve 400 si el ID no es numérico', async () => {
+    expect((await req('DELETE', '/items/abc', { key: TEST_API_KEY })).status).toBe(400)
   })
 })

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -1,0 +1,8 @@
+import { drizzle } from 'drizzle-orm/d1'
+import * as schema from './schema'
+
+export function createDb(d1: D1Database) {
+  return drizzle(d1, { schema })
+}
+
+export type AppDb = ReturnType<typeof createDb>

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1,0 +1,43 @@
+import { sql } from 'drizzle-orm'
+import { integer, real, sqliteTable, text } from 'drizzle-orm/sqlite-core'
+
+export const categories = sqliteTable('categories', {
+  id: integer('id').primaryKey({ autoIncrement: true }),
+  name: text('name').notNull(),
+  description: text('description'),
+  created_at: text('created_at').notNull().default(sql`(datetime('now'))`),
+})
+
+export const users = sqliteTable('users', {
+  id: integer('id').primaryKey({ autoIncrement: true }),
+  name: text('name').notNull(),
+  email: text('email').notNull().unique(),
+  created_at: text('created_at').notNull().default(sql`(datetime('now'))`),
+})
+
+export const items = sqliteTable('items', {
+  id: integer('id').primaryKey({ autoIncrement: true }),
+  name: text('name').notNull(),
+  description: text('description'),
+  price: real('price').notNull().default(0),
+  category_id: integer('category_id').references(() => categories.id),
+  created_at: text('created_at').notNull().default(sql`(datetime('now'))`),
+})
+
+export const orders = sqliteTable('orders', {
+  id: integer('id').primaryKey({ autoIncrement: true }),
+  user_id: integer('user_id').notNull().references(() => users.id),
+  status: text('status', { enum: ['pending', 'confirmed', 'shipped', 'delivered'] })
+    .notNull()
+    .default('pending'),
+  total: real('total').notNull().default(0),
+  created_at: text('created_at').notNull().default(sql`(datetime('now'))`),
+})
+
+export const orderItems = sqliteTable('order_items', {
+  id: integer('id').primaryKey({ autoIncrement: true }),
+  order_id: integer('order_id').notNull().references(() => orders.id),
+  item_id: integer('item_id').notNull().references(() => items.id),
+  quantity: integer('quantity').notNull(),
+  unit_price: real('unit_price').notNull(),
+})

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,127 +1,37 @@
-import { Hono } from 'hono';
-import { cors } from 'hono/cors';
-import { logger } from 'hono/logger';
-import { apiKeyAuth } from './middleware/apiKey';
-import type { Bindings, Item, CreateItemBody, UpdateItemBody } from './types';
+import { fromHono } from 'chanfana'
+import { Hono } from 'hono'
+import { cors } from 'hono/cors'
+import { logger } from 'hono/logger'
+import { apiKeyAuth } from './middleware/apiKey'
+import { ItemsCreate, ItemsDelete, ItemsGet, ItemsList, ItemsUpdate } from './routes/items'
+import type { Bindings } from './types'
 
-const NAME_MAX = 200;
-const DESC_MAX = 1000;
-const PRICE_MAX = 999_999;
+const app = new Hono<{ Bindings: Bindings }>()
 
-const app = new Hono<{ Bindings: Bindings }>();
+app.use('*', logger())
+app.use('*', (c, next) => cors({ origin: c.env.ALLOWED_ORIGIN })(c, next))
 
-app.use('*', logger());
-app.use('*', (c, next) =>
-  cors({ origin: c.env.ALLOWED_ORIGIN })(c, next)
-);
+app.get('/', (c) => c.json({ name: 'cloudfire-apiv1', status: 'ok', version: '2.0.0' }))
 
-app.get('/', (c) => {
-  return c.json({ name: 'cloudfire-apiv1', status: 'ok', version: '1.0.0' });
-});
+app.on(['POST', 'PUT', 'DELETE'], '/*', apiKeyAuth)
 
-// GET /items — listar todos
-app.get('/items', async (c) => {
-  const { results } = await c.env.DB.prepare(
-    'SELECT * FROM items ORDER BY created_at DESC'
-  ).all<Item>();
-  return c.json({ data: results, count: results.length });
-});
+const openapi = fromHono(app, {
+  docs_url: '/docs',
+  openapi_url: '/openapi.json',
+  schema: {
+    info: { title: 'cloudfire-apiv1', version: '2.0.0' },
+    components: {
+      securitySchemes: {
+        ApiKeyAuth: { type: 'apiKey', in: 'header', name: 'X-API-Key' },
+      },
+    },
+  },
+} as any) as any
 
-// GET /items/:id — obtener uno
-app.get('/items/:id', async (c) => {
-  const id = Number(c.req.param('id'));
-  if (isNaN(id)) return c.json({ error: 'ID inválido' }, 400);
+openapi.get('/items', ItemsList)
+openapi.get('/items/:id', ItemsGet)
+openapi.post('/items', ItemsCreate)
+openapi.put('/items/:id', ItemsUpdate)
+openapi.delete('/items/:id', ItemsDelete)
 
-  const item = await c.env.DB.prepare('SELECT * FROM items WHERE id = ?')
-    .bind(id)
-    .first<Item>();
-
-  if (!item) return c.json({ error: 'Item no encontrado' }, 404);
-  return c.json({ data: item });
-});
-
-// POST /items — crear (requiere API key)
-app.post('/items', apiKeyAuth, async (c) => {
-  const body = await c.req.json<CreateItemBody>().catch(() => null);
-  if (!body) return c.json({ error: 'Body inválido' }, 400);
-
-  const { name, description = null, price } = body;
-
-  if (!name || typeof name !== 'string' || name.trim().length === 0) {
-    return c.json({ error: 'name es requerido' }, 422);
-  }
-  if (name.length > NAME_MAX) {
-    return c.json({ error: `name no puede superar ${NAME_MAX} caracteres` }, 422);
-  }
-  if (description !== null && description !== undefined && description.length > DESC_MAX) {
-    return c.json({ error: `description no puede superar ${DESC_MAX} caracteres` }, 422);
-  }
-  if (typeof price !== 'number' || price < 0 || price > PRICE_MAX) {
-    return c.json({ error: `price debe ser un número entre 0 y ${PRICE_MAX}` }, 422);
-  }
-
-  const result = await c.env.DB.prepare(
-    'INSERT INTO items (name, description, price) VALUES (?, ?, ?) RETURNING *'
-  )
-    .bind(name.trim(), description, price)
-    .first<Item>();
-
-  return c.json({ data: result }, 201);
-});
-
-// PUT /items/:id — actualizar (requiere API key)
-app.put('/items/:id', apiKeyAuth, async (c) => {
-  const id = Number(c.req.param('id'));
-  if (isNaN(id)) return c.json({ error: 'ID inválido' }, 400);
-
-  const body = await c.req.json<UpdateItemBody>().catch(() => null);
-  if (!body) return c.json({ error: 'Body inválido' }, 400);
-
-  if (body.name !== undefined) {
-    if (typeof body.name !== 'string' || body.name.trim().length === 0) {
-      return c.json({ error: 'name no puede estar vacío' }, 422);
-    }
-    if (body.name.length > NAME_MAX) {
-      return c.json({ error: `name no puede superar ${NAME_MAX} caracteres` }, 422);
-    }
-  }
-  if (body.description !== undefined && body.description !== null && body.description.length > DESC_MAX) {
-    return c.json({ error: `description no puede superar ${DESC_MAX} caracteres` }, 422);
-  }
-  if (body.price !== undefined && (typeof body.price !== 'number' || body.price < 0 || body.price > PRICE_MAX)) {
-    return c.json({ error: `price debe ser un número entre 0 y ${PRICE_MAX}` }, 422);
-  }
-
-  const existing = await c.env.DB.prepare('SELECT * FROM items WHERE id = ?')
-    .bind(id)
-    .first<Item>();
-  if (!existing) return c.json({ error: 'Item no encontrado' }, 404);
-
-  const name = body.name !== undefined ? body.name.trim() : existing.name;
-  const description = body.description !== undefined ? body.description : existing.description;
-  const price = body.price ?? existing.price;
-
-  const updated = await c.env.DB.prepare(
-    'UPDATE items SET name = ?, description = ?, price = ? WHERE id = ? RETURNING *'
-  )
-    .bind(name, description, price, id)
-    .first<Item>();
-
-  return c.json({ data: updated });
-});
-
-// DELETE /items/:id — eliminar (requiere API key)
-app.delete('/items/:id', apiKeyAuth, async (c) => {
-  const id = Number(c.req.param('id'));
-  if (isNaN(id)) return c.json({ error: 'ID inválido' }, 400);
-
-  const existing = await c.env.DB.prepare('SELECT id FROM items WHERE id = ?')
-    .bind(id)
-    .first();
-  if (!existing) return c.json({ error: 'Item no encontrado' }, 404);
-
-  await c.env.DB.prepare('DELETE FROM items WHERE id = ?').bind(id).run();
-  return c.json({ message: 'Item eliminado' });
-});
-
-export default app;
+export default app

--- a/src/repositories/items.repository.ts
+++ b/src/repositories/items.repository.ts
@@ -1,0 +1,66 @@
+import { eq } from 'drizzle-orm'
+import type { AppDb } from '../db'
+import { items } from '../db/schema'
+import type { Item } from '../types'
+
+export async function findAllItems(db: AppDb, categoryId?: number): Promise<Item[]> {
+  if (categoryId !== undefined) {
+    return db.select().from(items).where(eq(items.category_id, categoryId))
+  }
+
+  return db.select().from(items)
+}
+
+export async function findItemById(db: AppDb, id: number): Promise<Item | null> {
+  const rows = await db.select().from(items).where(eq(items.id, id)).limit(1)
+  return rows[0] ?? null
+}
+
+type ItemCreateInput = {
+  name: string
+  description?: string | null
+  price: number
+  category_id?: number | null
+}
+
+type ItemUpdateInput = {
+  name?: string
+  description?: string | null
+  price?: number
+  category_id?: number | null
+}
+
+export async function createItem(db: AppDb, data: ItemCreateInput): Promise<Item> {
+  const rows = await db
+    .insert(items)
+    .values({
+      name: data.name.trim(),
+      description: data.description ?? null,
+      price: data.price,
+      category_id: data.category_id ?? null,
+    })
+    .returning()
+
+  return rows[0] as Item
+}
+
+export async function updateItem(db: AppDb, id: number, data: ItemUpdateInput): Promise<Item | null> {
+  const patch: Partial<typeof items.$inferInsert> = {}
+
+  if (data.name !== undefined) patch.name = data.name.trim()
+  if ('description' in data) patch.description = data.description ?? null
+  if (data.price !== undefined) patch.price = data.price
+  if ('category_id' in data) patch.category_id = data.category_id ?? null
+
+  if (Object.keys(patch).length === 0) {
+    return findItemById(db, id)
+  }
+
+  const rows = await db.update(items).set(patch).where(eq(items.id, id)).returning()
+  return rows[0] ?? null
+}
+
+export async function deleteItem(db: AppDb, id: number): Promise<boolean> {
+  const rows = await db.delete(items).where(eq(items.id, id)).returning()
+  return rows.length > 0
+}

--- a/src/routes/items.ts
+++ b/src/routes/items.ts
@@ -1,0 +1,162 @@
+import { OpenAPIRoute } from 'chanfana'
+import { z } from 'zod'
+import { createDb } from '../db'
+import {
+  createItem,
+  deleteItem,
+  findAllItems,
+  findItemById,
+  updateItem,
+} from '../repositories/items.repository'
+import {
+  CreateItemSchema,
+  ItemIdParamSchema,
+  ItemSchema,
+  ItemsQuerySchema,
+  UpdateItemSchema,
+} from '../schemas/items.schema'
+import type { Bindings } from '../types'
+import type { Context } from 'hono'
+
+type AppCtx = Context<{ Bindings: Bindings }>
+
+const ItemsResponse = z.object({ data: z.array(ItemSchema), count: z.number() })
+const ItemResponse = z.object({ data: ItemSchema })
+const ErrorResponse = z.object({ error: z.string() })
+const DeleteResponse = z.object({ message: z.string() })
+
+export class ItemsList extends OpenAPIRoute {
+  schema = {
+    tags: ['Items'],
+    summary: 'List all items',
+    request: { query: ItemsQuerySchema },
+    responses: {
+      200: { description: 'OK', content: { 'application/json': { schema: ItemsResponse } } },
+      400: { description: 'Invalid query', content: { 'application/json': { schema: ErrorResponse } } },
+    },
+  } as any
+
+  async handle(c: AppCtx) {
+    const queryResult = ItemsQuerySchema.safeParse(Object.fromEntries(new URL(c.req.url).searchParams))
+    if (!queryResult.success) {
+      return c.json({ error: queryResult.error.issues[0]?.message ?? 'Query inválida' }, 400)
+    }
+
+    const db = createDb(c.env.DB)
+    const data = await findAllItems(db, queryResult.data.category_id)
+    return c.json({ data, count: data.length })
+  }
+}
+
+export class ItemsGet extends OpenAPIRoute {
+  schema = {
+    tags: ['Items'],
+    summary: 'Get item by ID',
+    request: { params: ItemIdParamSchema },
+    responses: {
+      200: { description: 'OK', content: { 'application/json': { schema: ItemResponse } } },
+      400: { description: 'Invalid ID', content: { 'application/json': { schema: ErrorResponse } } },
+      404: { description: 'Not found', content: { 'application/json': { schema: ErrorResponse } } },
+    },
+  } as any
+
+  async handle(c: AppCtx) {
+    const paramsResult = ItemIdParamSchema.safeParse(c.req.param())
+    if (!paramsResult.success) {
+      return c.json({ error: paramsResult.error.issues[0]?.message ?? 'ID inválido' }, 400)
+    }
+
+    const db = createDb(c.env.DB)
+    const item = await findItemById(db, paramsResult.data.id)
+    if (!item) return c.json({ error: 'Item no encontrado' }, 404)
+
+    return c.json({ data: item })
+  }
+}
+
+export class ItemsCreate extends OpenAPIRoute {
+  schema = {
+    tags: ['Items'],
+    summary: 'Create item',
+    security: [{ ApiKeyAuth: [] }],
+    request: { body: { content: { 'application/json': { schema: CreateItemSchema } } } },
+    responses: {
+      201: { description: 'Created', content: { 'application/json': { schema: ItemResponse } } },
+      422: { description: 'Validation error', content: { 'application/json': { schema: ErrorResponse } } },
+    },
+  } as any
+
+  async handle(c: AppCtx) {
+    const bodyResult = CreateItemSchema.safeParse(await c.req.json().catch(() => null))
+    if (!bodyResult.success) {
+      return c.json({ error: bodyResult.error.issues[0]?.message ?? 'Datos inválidos' }, 422)
+    }
+
+    const db = createDb(c.env.DB)
+    const item = await createItem(db, bodyResult.data)
+    return c.json({ data: item }, 201)
+  }
+}
+
+export class ItemsUpdate extends OpenAPIRoute {
+  schema = {
+    tags: ['Items'],
+    summary: 'Update item',
+    security: [{ ApiKeyAuth: [] }],
+    request: {
+      params: ItemIdParamSchema,
+      body: { content: { 'application/json': { schema: UpdateItemSchema } } },
+    },
+    responses: {
+      200: { description: 'OK', content: { 'application/json': { schema: ItemResponse } } },
+      400: { description: 'Invalid ID', content: { 'application/json': { schema: ErrorResponse } } },
+      404: { description: 'Not found', content: { 'application/json': { schema: ErrorResponse } } },
+      422: { description: 'Validation error', content: { 'application/json': { schema: ErrorResponse } } },
+    },
+  } as any
+
+  async handle(c: AppCtx) {
+    const paramsResult = ItemIdParamSchema.safeParse(c.req.param())
+    if (!paramsResult.success) {
+      return c.json({ error: paramsResult.error.issues[0]?.message ?? 'ID inválido' }, 400)
+    }
+
+    const bodyResult = UpdateItemSchema.safeParse(await c.req.json().catch(() => null))
+    if (!bodyResult.success) {
+      return c.json({ error: bodyResult.error.issues[0]?.message ?? 'Datos inválidos' }, 422)
+    }
+
+    const db = createDb(c.env.DB)
+    const item = await updateItem(db, paramsResult.data.id, bodyResult.data)
+    if (!item) return c.json({ error: 'Item no encontrado' }, 404)
+
+    return c.json({ data: item })
+  }
+}
+
+export class ItemsDelete extends OpenAPIRoute {
+  schema = {
+    tags: ['Items'],
+    summary: 'Delete item',
+    security: [{ ApiKeyAuth: [] }],
+    request: { params: ItemIdParamSchema },
+    responses: {
+      200: { description: 'OK', content: { 'application/json': { schema: DeleteResponse } } },
+      400: { description: 'Invalid ID', content: { 'application/json': { schema: ErrorResponse } } },
+      404: { description: 'Not found', content: { 'application/json': { schema: ErrorResponse } } },
+    },
+  } as any
+
+  async handle(c: AppCtx) {
+    const paramsResult = ItemIdParamSchema.safeParse(c.req.param())
+    if (!paramsResult.success) {
+      return c.json({ error: paramsResult.error.issues[0]?.message ?? 'ID inválido' }, 400)
+    }
+
+    const db = createDb(c.env.DB)
+    const deleted = await deleteItem(db, paramsResult.data.id)
+    if (!deleted) return c.json({ error: 'Item no encontrado' }, 404)
+
+    return c.json({ message: 'Item eliminado' })
+  }
+}

--- a/src/schemas/items.schema.ts
+++ b/src/schemas/items.schema.ts
@@ -1,0 +1,32 @@
+import { z } from 'zod'
+
+export const ItemSchema = z.object({
+  id: z.number().int(),
+  name: z.string(),
+  description: z.string().nullable(),
+  price: z.number(),
+  category_id: z.number().int().nullable(),
+  created_at: z.string(),
+})
+
+export const CreateItemSchema = z.object({
+  name: z.string().trim().min(1).max(200),
+  description: z.string().max(1000).nullable().optional(),
+  price: z.number().min(0).max(999_999),
+  category_id: z.number().int().positive().nullable().optional(),
+})
+
+export const UpdateItemSchema = z.object({
+  name: z.string().trim().min(1).max(200).optional(),
+  description: z.string().max(1000).nullable().optional(),
+  price: z.number().min(0).max(999_999).optional(),
+  category_id: z.number().int().positive().nullable().optional(),
+})
+
+export const ItemIdParamSchema = z.object({
+  id: z.coerce.number().int().positive(),
+})
+
+export const ItemsQuerySchema = z.object({
+  category_id: z.coerce.number().int().positive().optional(),
+})

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,25 +1,14 @@
-export interface Item {
-  id: number;
-  name: string;
-  description: string | null;
-  price: number;
-  created_at: string;
-}
+import type { InferSelectModel } from 'drizzle-orm'
+import type * as schema from './db/schema'
 
-export interface CreateItemBody {
-  name: string;
-  description?: string;
-  price: number;
-}
-
-export interface UpdateItemBody {
-  name?: string;
-  description?: string;
-  price?: number;
-}
+export type Category = InferSelectModel<typeof schema.categories>
+export type User = InferSelectModel<typeof schema.users>
+export type Item = InferSelectModel<typeof schema.items>
+export type Order = InferSelectModel<typeof schema.orders>
+export type OrderItem = InferSelectModel<typeof schema.orderItems>
 
 export type Bindings = {
-  DB: D1Database;
-  API_KEY: string;
-  ALLOWED_ORIGIN: string;
-};
+  DB: D1Database
+  API_KEY: string
+  ALLOWED_ORIGIN: string
+}


### PR DESCRIPTION
## Summary
- migrate the API foundation from raw SQL handlers to Drizzle, Chanfana, and Zod for the items resource
- add the v2 database schema, repository, route, and OpenAPI wiring needed to continue the clean architecture rollout
- replace the regex D1 mock with in-memory etter-sqlite3 and expand the items test coverage to 26 cases

## Test plan
- [x] docker compose --profile test run --rm test npm run typecheck
- [x] docker compose --profile test run --rm test npm test
- [x] docker compose --profile test run --rm test npm run lint

Related to #12