### PR TITLE
feat(api): add categories resource

### DIFF
--- a/docs/superpowers/SESSION_STATE.md
+++ b/docs/superpowers/SESSION_STATE.md
@@ -1,7 +1,7 @@
 # Session State — cloudfire-apiv1 v2 upgrade
 
-**Last updated:** 2026-05-01  
-**Status:** PR1-a y PR1-b completados localmente en `feat/infra-drizzle-chanfana`. PR2-PR4 siguen pendientes.
+**Last updated:** 2026-05-03  
+**Status:** PR1 ya fue mergeado a `main` mediante el PR `#13`. PR2 (`feat/categories`) quedó implementado localmente y listo para PR. PR3-PR4 siguen pendientes.
 
 ---
 
@@ -14,6 +14,8 @@
 5. **Ambos commiteados y pusheados a main**
 6. **PR1-a ejecutado localmente** — issue `#12` creado y agregado al project board, branch `feat/infra-drizzle-chanfana` activa, deps v2 agregadas, `src/db/{schema.ts,index.ts}` creados, `migrations/0002_v2_schema.sql` creado y `src/types.ts` migrado
 7. **PR1-b ejecutado localmente** — `items` migrado a Zod + Drizzle + Chanfana (`src/schemas/items.schema.ts`, `src/repositories/items.repository.ts`, `src/routes/items.ts`, `src/index.ts`), mock D1 reemplazado por SQLite real en memoria con `better-sqlite3`, tests ampliados a 26 casos
+8. **PR1 mergeado** — PR `#13` (`feat(api): migrate items to drizzle and chanfana`) mergeado a `main`; checks de CI, tests y staging en verde
+9. **PR2 implementado localmente** — issue `#14` creado y agregado al board; branch `feat/categories` activa con `categories` en esquema/repository/route/index y tests CRUD validados
 
 ---
 
@@ -61,9 +63,9 @@ order_items id, order_id→orders, item_id→items, quantity, unit_price(snapsho
 
 | # | Task | Branch | Estado |
 |---|---|---|---|
-| PR1-a | GitHub issue + deps + Drizzle schema + migration + types | `feat/infra-drizzle-chanfana` | **COMPLETADO LOCAL** |
-| PR1-b | Items schema + repo + route + index.ts + d1-mock + tests + PR | `feat/infra-drizzle-chanfana` | **COMPLETADO LOCAL** |
-| PR2 | Categories resource completo + PR | `feat/categories` | **PENDIENTE** (espera PR1) |
+| PR1-a | GitHub issue + deps + Drizzle schema + migration + types | `feat/infra-drizzle-chanfana` | **MERGEADO EN MAIN** |
+| PR1-b | Items schema + repo + route + index.ts + d1-mock + tests + PR | `feat/infra-drizzle-chanfana` | **MERGEADO EN MAIN** |
+| PR2 | Categories resource completo + PR | `feat/categories` | **COMPLETADO LOCAL / LISTO PARA PR** |
 | PR3 | Users resource completo + PR | `feat/users` | **PENDIENTE** (espera PR1) |
 | PR4 | Orders resource + service + PR | `feat/orders` | **PENDIENTE** (espera PR1+PR3) |
 
@@ -74,11 +76,12 @@ order_items id, order_id→orders, item_id→items, quantity, unit_price(snapsho
 1. Leer este archivo
 2. Leer el plan completo: `docs/superpowers/plans/2026-05-01-apiv1-v2-clean-code.md`
 3. Verificar estado del repo: `git branch -a` y `git status`
-4. Hacer commit/push/PR de `feat/infra-drizzle-chanfana` o continuar con PR2 desde una branch nueva cuando se cierre PR1
+4. Hacer commit/push/PR de `feat/categories` y luego arrancar `PR3` desde una branch nueva (`feat/users`)
 5. Ejecutar con: invocar skill `superpowers:subagent-driven-development`
 6. Tests corren via Docker: `docker compose --profile test run --rm test`
 7. NUNCA correr `npm install` en el host — solo dentro de Docker
 8. `docker compose --profile test run --rm test npm run typecheck`, `npm test` y `npm run lint` pasan; lint deja warnings por casts de compatibilidad en Chanfana
+9. `categories` agrega 12 tests nuevos; suite total actual: 38 tests en verde
 
 ---
 
@@ -94,8 +97,8 @@ order_items id, order_id→orders, item_id→items, quantity, unit_price(snapsho
 
 ## Tasks del sistema (IDs)
 
-- Task #1 — PR1-a (infra): completed locally
-- Task #2 — PR1-b (items layer): completed locally
-- Task #3 — PR2 (categories): blocked por #1, #2
-- Task #4 — PR3 (users): blocked por #1, #2
-- Task #5 — PR4 (orders): blocked por #1, #2, #4
+- Task #1 — PR1-a (infra): merged into main
+- Task #2 — PR1-b (items layer): merged into main
+- Task #3 — PR2 (categories): completed locally, ready for PR
+- Task #4 — PR3 (users): pending after PR2
+- Task #5 — PR4 (orders): pending after PR2 and PR3

--- a/src/__tests__/categories.test.ts
+++ b/src/__tests__/categories.test.ts
@@ -1,0 +1,111 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import app from '../index'
+import { createTestEnv, TEST_API_KEY } from './setup'
+import type { Bindings } from '../types'
+
+let env: Bindings
+
+beforeEach(() => {
+  env = createTestEnv()
+})
+
+function req(method: string, path: string, opts: { body?: unknown; key?: string } = {}) {
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' }
+  if (opts.key) headers['X-API-Key'] = opts.key
+
+  return app.fetch(
+    new Request(`http://localhost${path}`, {
+      method,
+      headers,
+      body: opts.body ? JSON.stringify(opts.body) : undefined,
+    }),
+    env as unknown as Record<string, unknown>,
+  )
+}
+
+const get = (path: string) => req('GET', path)
+const post = (path: string, body: unknown, key?: string) => req('POST', path, { body, key })
+const put = (path: string, body: unknown) => req('PUT', path, { body, key: TEST_API_KEY })
+const del = (path: string) => req('DELETE', path, { key: TEST_API_KEY })
+
+describe('GET /categories', () => {
+  it('devuelve lista vacía inicialmente', async () => {
+    const res = await get('/categories')
+    expect(res.status).toBe(200)
+    const body = await res.json() as { data: unknown[]; count: number }
+    expect(body.data).toEqual([])
+    expect(body.count).toBe(0)
+  })
+})
+
+describe('POST /categories', () => {
+  it('crea una categoría válida', async () => {
+    const res = await post('/categories', { name: 'Electronica' }, TEST_API_KEY)
+    expect(res.status).toBe(201)
+    const body = await res.json() as { data: { name: string } }
+    expect(body.data.name).toBe('Electronica')
+  })
+
+  it('devuelve 401 sin API key', async () => {
+    expect((await post('/categories', { name: 'Test' })).status).toBe(401)
+  })
+
+  it('devuelve 422 si falta name', async () => {
+    expect((await post('/categories', { description: 'Solo desc' }, TEST_API_KEY)).status).toBe(422)
+  })
+
+  it('devuelve 422 si name supera 100 caracteres', async () => {
+    expect((await post('/categories', { name: 'A'.repeat(101) }, TEST_API_KEY)).status).toBe(422)
+  })
+})
+
+describe('GET /categories/:id', () => {
+  it('devuelve 404 si no existe', async () => {
+    expect((await get('/categories/999')).status).toBe(404)
+  })
+
+  it('devuelve 400 si ID no es numérico', async () => {
+    expect((await get('/categories/abc')).status).toBe(400)
+  })
+
+  it('devuelve la categoría si existe', async () => {
+    await post('/categories', { name: 'Ropa' }, TEST_API_KEY)
+    const list = await get('/categories').then((response: Response) => response.json()) as { data: Array<{ id: number }> }
+    const id = list.data[0]!.id
+    const res = await get(`/categories/${id}`)
+    expect(res.status).toBe(200)
+    const body = await res.json() as { data: { name: string } }
+    expect(body.data.name).toBe('Ropa')
+  })
+})
+
+describe('PUT /categories/:id', () => {
+  it('actualiza el nombre', async () => {
+    await post('/categories', { name: 'Vieja' }, TEST_API_KEY)
+    const list = await get('/categories').then((response: Response) => response.json()) as { data: Array<{ id: number }> }
+    const id = list.data[0]!.id
+    const res = await put(`/categories/${id}`, { name: 'Nueva' })
+    expect(res.status).toBe(200)
+    const body = await res.json() as { data: { name: string } }
+    expect(body.data.name).toBe('Nueva')
+  })
+
+  it('devuelve 404 si no existe', async () => {
+    expect((await put('/categories/999', { name: 'X' })).status).toBe(404)
+  })
+})
+
+describe('DELETE /categories/:id', () => {
+  it('elimina y confirma con 404', async () => {
+    await post('/categories', { name: 'Borrar' }, TEST_API_KEY)
+    const list = await get('/categories').then((response: Response) => response.json()) as { data: Array<{ id: number }> }
+    const id = list.data[0]!.id
+    expect((await del(`/categories/${id}`)).status).toBe(200)
+    expect((await get(`/categories/${id}`)).status).toBe(404)
+  })
+
+  it('devuelve 404 si no existe', async () => {
+    expect((await del('/categories/999')).status).toBe(404)
+  })
+}
+)

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,13 @@ import { Hono } from 'hono'
 import { cors } from 'hono/cors'
 import { logger } from 'hono/logger'
 import { apiKeyAuth } from './middleware/apiKey'
+import {
+  CategoriesCreate,
+  CategoriesDelete,
+  CategoriesGet,
+  CategoriesList,
+  CategoriesUpdate,
+} from './routes/categories'
 import { ItemsCreate, ItemsDelete, ItemsGet, ItemsList, ItemsUpdate } from './routes/items'
 import type { Bindings } from './types'
 
@@ -33,5 +40,10 @@ openapi.get('/items/:id', ItemsGet)
 openapi.post('/items', ItemsCreate)
 openapi.put('/items/:id', ItemsUpdate)
 openapi.delete('/items/:id', ItemsDelete)
+openapi.get('/categories', CategoriesList)
+openapi.get('/categories/:id', CategoriesGet)
+openapi.post('/categories', CategoriesCreate)
+openapi.put('/categories/:id', CategoriesUpdate)
+openapi.delete('/categories/:id', CategoriesDelete)
 
 export default app

--- a/src/repositories/categories.repository.ts
+++ b/src/repositories/categories.repository.ts
@@ -1,0 +1,54 @@
+import { eq } from 'drizzle-orm'
+import type { AppDb } from '../db'
+import { categories } from '../db/schema'
+import type { Category } from '../types'
+
+export async function findAllCategories(db: AppDb): Promise<Category[]> {
+  return db.select().from(categories)
+}
+
+export async function findCategoryById(db: AppDb, id: number): Promise<Category | null> {
+  const rows = await db.select().from(categories).where(eq(categories.id, id)).limit(1)
+  return rows[0] ?? null
+}
+
+type CategoryCreateInput = {
+  name: string
+  description?: string | null
+}
+
+type CategoryUpdateInput = {
+  name?: string
+  description?: string | null
+}
+
+export async function createCategory(db: AppDb, data: CategoryCreateInput): Promise<Category> {
+  const rows = await db
+    .insert(categories)
+    .values({
+      name: data.name.trim(),
+      description: data.description ?? null,
+    })
+    .returning()
+
+  return rows[0] as Category
+}
+
+export async function updateCategory(db: AppDb, id: number, data: CategoryUpdateInput): Promise<Category | null> {
+  const patch: Partial<typeof categories.$inferInsert> = {}
+
+  if (data.name !== undefined) patch.name = data.name.trim()
+  if ('description' in data) patch.description = data.description ?? null
+
+  if (Object.keys(patch).length === 0) {
+    return findCategoryById(db, id)
+  }
+
+  const rows = await db.update(categories).set(patch).where(eq(categories.id, id)).returning()
+  return rows[0] ?? null
+}
+
+export async function deleteCategory(db: AppDb, id: number): Promise<boolean> {
+  const rows = await db.delete(categories).where(eq(categories.id, id)).returning()
+  return rows.length > 0
+}

--- a/src/routes/categories.ts
+++ b/src/routes/categories.ts
@@ -1,0 +1,154 @@
+import { OpenAPIRoute } from 'chanfana'
+import type { Context } from 'hono'
+import { z } from 'zod'
+import { createDb } from '../db'
+import {
+  createCategory,
+  deleteCategory,
+  findAllCategories,
+  findCategoryById,
+  updateCategory,
+} from '../repositories/categories.repository'
+import {
+  CategoryIdParamSchema,
+  CategorySchema,
+  CreateCategorySchema,
+  UpdateCategorySchema,
+} from '../schemas/categories.schema'
+import type { Bindings } from '../types'
+
+type AppCtx = Context<{ Bindings: Bindings }>
+
+const CategoriesResponse = z.object({ data: z.array(CategorySchema), count: z.number() })
+const CategoryResponse = z.object({ data: CategorySchema })
+const ErrorResponse = z.object({ error: z.string() })
+const DeleteResponse = z.object({ message: z.string() })
+
+export class CategoriesList extends OpenAPIRoute {
+  schema = {
+    tags: ['Categories'],
+    summary: 'List all categories',
+    responses: {
+      200: { description: 'OK', content: { 'application/json': { schema: CategoriesResponse } } },
+    },
+  } as any
+
+  async handle(c: AppCtx) {
+    const db = createDb(c.env.DB)
+    const data = await findAllCategories(db)
+    return c.json({ data, count: data.length })
+  }
+}
+
+export class CategoriesGet extends OpenAPIRoute {
+  schema = {
+    tags: ['Categories'],
+    summary: 'Get category by ID',
+    request: { params: CategoryIdParamSchema },
+    responses: {
+      200: { description: 'OK', content: { 'application/json': { schema: CategoryResponse } } },
+      400: { description: 'Invalid ID', content: { 'application/json': { schema: ErrorResponse } } },
+      404: { description: 'Not found', content: { 'application/json': { schema: ErrorResponse } } },
+    },
+  } as any
+
+  async handle(c: AppCtx) {
+    const paramsResult = CategoryIdParamSchema.safeParse(c.req.param())
+    if (!paramsResult.success) {
+      return c.json({ error: paramsResult.error.issues[0]?.message ?? 'ID inválido' }, 400)
+    }
+
+    const db = createDb(c.env.DB)
+    const category = await findCategoryById(db, paramsResult.data.id)
+    if (!category) return c.json({ error: 'Categoria no encontrada' }, 404)
+
+    return c.json({ data: category })
+  }
+}
+
+export class CategoriesCreate extends OpenAPIRoute {
+  schema = {
+    tags: ['Categories'],
+    summary: 'Create category',
+    security: [{ ApiKeyAuth: [] }],
+    request: { body: { content: { 'application/json': { schema: CreateCategorySchema } } } },
+    responses: {
+      201: { description: 'Created', content: { 'application/json': { schema: CategoryResponse } } },
+      422: { description: 'Validation error', content: { 'application/json': { schema: ErrorResponse } } },
+    },
+  } as any
+
+  async handle(c: AppCtx) {
+    const bodyResult = CreateCategorySchema.safeParse(await c.req.json().catch(() => null))
+    if (!bodyResult.success) {
+      return c.json({ error: bodyResult.error.issues[0]?.message ?? 'Datos inválidos' }, 422)
+    }
+
+    const db = createDb(c.env.DB)
+    const category = await createCategory(db, bodyResult.data)
+    return c.json({ data: category }, 201)
+  }
+}
+
+export class CategoriesUpdate extends OpenAPIRoute {
+  schema = {
+    tags: ['Categories'],
+    summary: 'Update category',
+    security: [{ ApiKeyAuth: [] }],
+    request: {
+      params: CategoryIdParamSchema,
+      body: { content: { 'application/json': { schema: UpdateCategorySchema } } },
+    },
+    responses: {
+      200: { description: 'OK', content: { 'application/json': { schema: CategoryResponse } } },
+      400: { description: 'Invalid ID', content: { 'application/json': { schema: ErrorResponse } } },
+      404: { description: 'Not found', content: { 'application/json': { schema: ErrorResponse } } },
+      422: { description: 'Validation error', content: { 'application/json': { schema: ErrorResponse } } },
+    },
+  } as any
+
+  async handle(c: AppCtx) {
+    const paramsResult = CategoryIdParamSchema.safeParse(c.req.param())
+    if (!paramsResult.success) {
+      return c.json({ error: paramsResult.error.issues[0]?.message ?? 'ID inválido' }, 400)
+    }
+
+    const bodyResult = UpdateCategorySchema.safeParse(await c.req.json().catch(() => null))
+    if (!bodyResult.success) {
+      return c.json({ error: bodyResult.error.issues[0]?.message ?? 'Datos inválidos' }, 422)
+    }
+
+    const db = createDb(c.env.DB)
+    const category = await updateCategory(db, paramsResult.data.id, bodyResult.data)
+    if (!category) return c.json({ error: 'Categoria no encontrada' }, 404)
+
+    return c.json({ data: category })
+  }
+}
+
+export class CategoriesDelete extends OpenAPIRoute {
+  schema = {
+    tags: ['Categories'],
+    summary: 'Delete category',
+    security: [{ ApiKeyAuth: [] }],
+    request: { params: CategoryIdParamSchema },
+    responses: {
+      200: { description: 'OK', content: { 'application/json': { schema: DeleteResponse } } },
+      400: { description: 'Invalid ID', content: { 'application/json': { schema: ErrorResponse } } },
+      404: { description: 'Not found', content: { 'application/json': { schema: ErrorResponse } } },
+    },
+  } as any
+
+  async handle(c: AppCtx) {
+    const paramsResult = CategoryIdParamSchema.safeParse(c.req.param())
+    if (!paramsResult.success) {
+      return c.json({ error: paramsResult.error.issues[0]?.message ?? 'ID inválido' }, 400)
+    }
+
+    const db = createDb(c.env.DB)
+    const deleted = await deleteCategory(db, paramsResult.data.id)
+    if (!deleted) return c.json({ error: 'Categoria no encontrada' }, 404)
+
+    return c.json({ message: 'Categoria eliminada' })
+  }
+}

--- a/src/schemas/categories.schema.ts
+++ b/src/schemas/categories.schema.ts
@@ -1,0 +1,22 @@
+import { z } from 'zod'
+
+export const CategorySchema = z.object({
+  id: z.number().int(),
+  name: z.string(),
+  description: z.string().nullable(),
+  created_at: z.string(),
+})
+
+export const CreateCategorySchema = z.object({
+  name: z.string().trim().min(1).max(100),
+  description: z.string().max(500).nullable().optional(),
+})
+
+export const UpdateCategorySchema = z.object({
+  name: z.string().trim().min(1).max(100).optional(),
+  description: z.string().max(500).nullable().optional(),
+})
+
+export const CategoryIdParamSchema = z.object({
+  id: z.coerce.number().int().positive(),
+})


### PR DESCRIPTION
## Summary
- add full CRUD for the categories resource on top of the v2 Drizzle + Zod + Chanfana stack
- register the new OpenAPI routes in src/index.ts so categories follows the same layered architecture as items
- add dedicated CRUD tests for categories while keeping the full suite green

## Test plan
- [x] docker compose --profile test run --rm test npm run typecheck
- [x] docker compose --profile test run --rm test npm test
- [x] docker compose --profile test run --rm test npm run lint

Related to #14