### PR TITLE
feat(api): add users resource

### DIFF
--- a/docs/superpowers/SESSION_STATE.md
+++ b/docs/superpowers/SESSION_STATE.md
@@ -1,7 +1,7 @@
 # Session State — cloudfire-apiv1 v2 upgrade
 
 **Last updated:** 2026-05-03  
-**Status:** PR1 ya fue mergeado a `main` mediante el PR `#13`. PR2 (`feat/categories`) quedó implementado localmente y listo para PR. PR3-PR4 siguen pendientes.
+**Status:** PR1 y PR2 ya fueron mergeados a `main` mediante los PRs `#13` y `#15`. PR3 (`feat/users`) quedó implementado localmente y listo para PR. PR4 sigue pendiente.
 
 ---
 
@@ -16,6 +16,8 @@
 7. **PR1-b ejecutado localmente** — `items` migrado a Zod + Drizzle + Chanfana (`src/schemas/items.schema.ts`, `src/repositories/items.repository.ts`, `src/routes/items.ts`, `src/index.ts`), mock D1 reemplazado por SQLite real en memoria con `better-sqlite3`, tests ampliados a 26 casos
 8. **PR1 mergeado** — PR `#13` (`feat(api): migrate items to drizzle and chanfana`) mergeado a `main`; checks de CI, tests y staging en verde
 9. **PR2 implementado localmente** — issue `#14` creado y agregado al board; branch `feat/categories` activa con `categories` en esquema/repository/route/index y tests CRUD validados
+10. **PR2 mergeado** — PR `#15` (`feat(api): add categories resource`) mergeado a `main`; checks de CI, tests y staging en verde
+11. **PR3 implementado localmente** — issue `#16` creado y agregado al board; branch `feat/users` activa con `users` en schema/repository/route/index y tests CRUD validados
 
 ---
 
@@ -65,9 +67,9 @@ order_items id, order_id→orders, item_id→items, quantity, unit_price(snapsho
 |---|---|---|---|
 | PR1-a | GitHub issue + deps + Drizzle schema + migration + types | `feat/infra-drizzle-chanfana` | **MERGEADO EN MAIN** |
 | PR1-b | Items schema + repo + route + index.ts + d1-mock + tests + PR | `feat/infra-drizzle-chanfana` | **MERGEADO EN MAIN** |
-| PR2 | Categories resource completo + PR | `feat/categories` | **COMPLETADO LOCAL / LISTO PARA PR** |
-| PR3 | Users resource completo + PR | `feat/users` | **PENDIENTE** (espera PR1) |
-| PR4 | Orders resource + service + PR | `feat/orders` | **PENDIENTE** (espera PR1+PR3) |
+| PR2 | Categories resource completo + PR | `feat/categories` | **MERGEADO EN MAIN** |
+| PR3 | Users resource completo + PR | `feat/users` | **COMPLETADO LOCAL / LISTO PARA PR** |
+| PR4 | Orders resource + service + PR | `feat/orders` | **PENDIENTE** (espera PR3) |
 
 ---
 
@@ -76,12 +78,13 @@ order_items id, order_id→orders, item_id→items, quantity, unit_price(snapsho
 1. Leer este archivo
 2. Leer el plan completo: `docs/superpowers/plans/2026-05-01-apiv1-v2-clean-code.md`
 3. Verificar estado del repo: `git branch -a` y `git status`
-4. Hacer commit/push/PR de `feat/categories` y luego arrancar `PR3` desde una branch nueva (`feat/users`)
+4. Hacer commit/push/PR de `feat/users` y luego arrancar `PR4` desde `feat/orders`
 5. Ejecutar con: invocar skill `superpowers:subagent-driven-development`
 6. Tests corren via Docker: `docker compose --profile test run --rm test`
 7. NUNCA correr `npm install` en el host — solo dentro de Docker
 8. `docker compose --profile test run --rm test npm run typecheck`, `npm test` y `npm run lint` pasan; lint deja warnings por casts de compatibilidad en Chanfana
 9. `categories` agrega 12 tests nuevos; suite total actual: 38 tests en verde
+10. `users` agrega 12 tests nuevos; suite total actual: 50 tests en verde
 
 ---
 
@@ -99,6 +102,6 @@ order_items id, order_id→orders, item_id→items, quantity, unit_price(snapsho
 
 - Task #1 — PR1-a (infra): merged into main
 - Task #2 — PR1-b (items layer): merged into main
-- Task #3 — PR2 (categories): completed locally, ready for PR
-- Task #4 — PR3 (users): pending after PR2
-- Task #5 — PR4 (orders): pending after PR2 and PR3
+- Task #3 — PR2 (categories): merged into main
+- Task #4 — PR3 (users): completed locally, ready for PR
+- Task #5 — PR4 (orders): pending after PR3

--- a/src/__tests__/users.test.ts
+++ b/src/__tests__/users.test.ts
@@ -1,0 +1,111 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import app from '../index'
+import { createTestEnv, TEST_API_KEY } from './setup'
+import type { Bindings } from '../types'
+
+let env: Bindings
+
+beforeEach(() => {
+  env = createTestEnv()
+})
+
+function req(method: string, path: string, opts: { body?: unknown; key?: string } = {}) {
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' }
+  if (opts.key) headers['X-API-Key'] = opts.key
+
+  return app.fetch(
+    new Request(`http://localhost${path}`, {
+      method,
+      headers,
+      body: opts.body ? JSON.stringify(opts.body) : undefined,
+    }),
+    env as unknown as Record<string, unknown>,
+  )
+}
+
+const get = (path: string) => req('GET', path)
+const post = (path: string, body: unknown, key?: string) => req('POST', path, { body, key })
+const put = (path: string, body: unknown) => req('PUT', path, { body, key: TEST_API_KEY })
+const del = (path: string) => req('DELETE', path, { key: TEST_API_KEY })
+
+describe('GET /users', () => {
+  it('devuelve lista vacía inicialmente', async () => {
+    const res = await get('/users')
+    expect(res.status).toBe(200)
+    const body = await res.json() as { data: unknown[]; count: number }
+    expect(body.data).toEqual([])
+    expect(body.count).toBe(0)
+  })
+})
+
+describe('POST /users', () => {
+  it('crea un usuario válido', async () => {
+    const res = await post('/users', { name: 'Juan', email: 'JUAN@MAIL.COM' }, TEST_API_KEY)
+    expect(res.status).toBe(201)
+    const body = await res.json() as { data: { name: string; email: string } }
+    expect(body.data.name).toBe('Juan')
+    expect(body.data.email).toBe('juan@mail.com')
+  })
+
+  it('devuelve 401 sin API key', async () => {
+    expect((await post('/users', { name: 'Test', email: 'a@a.com' })).status).toBe(401)
+  })
+
+  it('devuelve 422 si falta email', async () => {
+    expect((await post('/users', { name: 'Solo nombre' }, TEST_API_KEY)).status).toBe(422)
+  })
+
+  it('devuelve 422 si email no es válido', async () => {
+    expect((await post('/users', { name: 'Test', email: 'invalido' }, TEST_API_KEY)).status).toBe(422)
+  })
+})
+
+describe('GET /users/:id', () => {
+  it('devuelve 404 si no existe', async () => {
+    expect((await get('/users/999')).status).toBe(404)
+  })
+
+  it('devuelve 400 si ID no es numérico', async () => {
+    expect((await get('/users/abc')).status).toBe(400)
+  })
+
+  it('devuelve el usuario si existe', async () => {
+    await post('/users', { name: 'Ana', email: 'ana@mail.com' }, TEST_API_KEY)
+    const list = await get('/users').then((response: Response) => response.json()) as { data: Array<{ id: number }> }
+    const id = list.data[0]!.id
+    const res = await get(`/users/${id}`)
+    expect(res.status).toBe(200)
+    const body = await res.json() as { data: { name: string } }
+    expect(body.data.name).toBe('Ana')
+  })
+})
+
+describe('PUT /users/:id', () => {
+  it('actualiza el email', async () => {
+    await post('/users', { name: 'Pedro', email: 'pedro@mail.com' }, TEST_API_KEY)
+    const list = await get('/users').then((response: Response) => response.json()) as { data: Array<{ id: number }> }
+    const id = list.data[0]!.id
+    const res = await put(`/users/${id}`, { email: 'NUEVO@MAIL.COM' })
+    expect(res.status).toBe(200)
+    const body = await res.json() as { data: { email: string } }
+    expect(body.data.email).toBe('nuevo@mail.com')
+  })
+
+  it('devuelve 404 si no existe', async () => {
+    expect((await put('/users/999', { name: 'X' })).status).toBe(404)
+  })
+})
+
+describe('DELETE /users/:id', () => {
+  it('elimina y confirma con 404', async () => {
+    await post('/users', { name: 'Borrar', email: 'borrar@mail.com' }, TEST_API_KEY)
+    const list = await get('/users').then((response: Response) => response.json()) as { data: Array<{ id: number }> }
+    const id = list.data[0]!.id
+    expect((await del(`/users/${id}`)).status).toBe(200)
+    expect((await get(`/users/${id}`)).status).toBe(404)
+  })
+
+  it('devuelve 404 si no existe', async () => {
+    expect((await del('/users/999')).status).toBe(404)
+  })
+})

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import {
   CategoriesUpdate,
 } from './routes/categories'
 import { ItemsCreate, ItemsDelete, ItemsGet, ItemsList, ItemsUpdate } from './routes/items'
+import { UsersCreate, UsersDelete, UsersGet, UsersList, UsersUpdate } from './routes/users'
 import type { Bindings } from './types'
 
 const app = new Hono<{ Bindings: Bindings }>()
@@ -45,5 +46,10 @@ openapi.get('/categories/:id', CategoriesGet)
 openapi.post('/categories', CategoriesCreate)
 openapi.put('/categories/:id', CategoriesUpdate)
 openapi.delete('/categories/:id', CategoriesDelete)
+openapi.get('/users', UsersList)
+openapi.get('/users/:id', UsersGet)
+openapi.post('/users', UsersCreate)
+openapi.put('/users/:id', UsersUpdate)
+openapi.delete('/users/:id', UsersDelete)
 
 export default app

--- a/src/repositories/users.repository.ts
+++ b/src/repositories/users.repository.ts
@@ -1,0 +1,54 @@
+import { eq } from 'drizzle-orm'
+import type { AppDb } from '../db'
+import { users } from '../db/schema'
+import type { User } from '../types'
+
+export async function findAllUsers(db: AppDb): Promise<User[]> {
+  return db.select().from(users)
+}
+
+export async function findUserById(db: AppDb, id: number): Promise<User | null> {
+  const rows = await db.select().from(users).where(eq(users.id, id)).limit(1)
+  return rows[0] ?? null
+}
+
+type UserCreateInput = {
+  name: string
+  email: string
+}
+
+type UserUpdateInput = {
+  name?: string
+  email?: string
+}
+
+export async function createUser(db: AppDb, data: UserCreateInput): Promise<User> {
+  const rows = await db
+    .insert(users)
+    .values({
+      name: data.name.trim(),
+      email: data.email.toLowerCase().trim(),
+    })
+    .returning()
+
+  return rows[0] as User
+}
+
+export async function updateUser(db: AppDb, id: number, data: UserUpdateInput): Promise<User | null> {
+  const patch: Partial<typeof users.$inferInsert> = {}
+
+  if (data.name !== undefined) patch.name = data.name.trim()
+  if (data.email !== undefined) patch.email = data.email.toLowerCase().trim()
+
+  if (Object.keys(patch).length === 0) {
+    return findUserById(db, id)
+  }
+
+  const rows = await db.update(users).set(patch).where(eq(users.id, id)).returning()
+  return rows[0] ?? null
+}
+
+export async function deleteUser(db: AppDb, id: number): Promise<boolean> {
+  const rows = await db.delete(users).where(eq(users.id, id)).returning()
+  return rows.length > 0
+}

--- a/src/routes/users.ts
+++ b/src/routes/users.ts
@@ -1,0 +1,154 @@
+import { OpenAPIRoute } from 'chanfana'
+import type { Context } from 'hono'
+import { z } from 'zod'
+import { createDb } from '../db'
+import {
+  createUser,
+  deleteUser,
+  findAllUsers,
+  findUserById,
+  updateUser,
+} from '../repositories/users.repository'
+import {
+  CreateUserSchema,
+  UpdateUserSchema,
+  UserIdParamSchema,
+  UserSchema,
+} from '../schemas/users.schema'
+import type { Bindings } from '../types'
+
+type AppCtx = Context<{ Bindings: Bindings }>
+
+const UsersResponse = z.object({ data: z.array(UserSchema), count: z.number() })
+const UserResponse = z.object({ data: UserSchema })
+const ErrorResponse = z.object({ error: z.string() })
+const DeleteResponse = z.object({ message: z.string() })
+
+export class UsersList extends OpenAPIRoute {
+  schema = {
+    tags: ['Users'],
+    summary: 'List all users',
+    responses: {
+      200: { description: 'OK', content: { 'application/json': { schema: UsersResponse } } },
+    },
+  } as any
+
+  async handle(c: AppCtx) {
+    const db = createDb(c.env.DB)
+    const data = await findAllUsers(db)
+    return c.json({ data, count: data.length })
+  }
+}
+
+export class UsersGet extends OpenAPIRoute {
+  schema = {
+    tags: ['Users'],
+    summary: 'Get user by ID',
+    request: { params: UserIdParamSchema },
+    responses: {
+      200: { description: 'OK', content: { 'application/json': { schema: UserResponse } } },
+      400: { description: 'Invalid ID', content: { 'application/json': { schema: ErrorResponse } } },
+      404: { description: 'Not found', content: { 'application/json': { schema: ErrorResponse } } },
+    },
+  } as any
+
+  async handle(c: AppCtx) {
+    const paramsResult = UserIdParamSchema.safeParse(c.req.param())
+    if (!paramsResult.success) {
+      return c.json({ error: paramsResult.error.issues[0]?.message ?? 'ID inválido' }, 400)
+    }
+
+    const db = createDb(c.env.DB)
+    const user = await findUserById(db, paramsResult.data.id)
+    if (!user) return c.json({ error: 'Usuario no encontrado' }, 404)
+
+    return c.json({ data: user })
+  }
+}
+
+export class UsersCreate extends OpenAPIRoute {
+  schema = {
+    tags: ['Users'],
+    summary: 'Create user',
+    security: [{ ApiKeyAuth: [] }],
+    request: { body: { content: { 'application/json': { schema: CreateUserSchema } } } },
+    responses: {
+      201: { description: 'Created', content: { 'application/json': { schema: UserResponse } } },
+      422: { description: 'Validation error', content: { 'application/json': { schema: ErrorResponse } } },
+    },
+  } as any
+
+  async handle(c: AppCtx) {
+    const bodyResult = CreateUserSchema.safeParse(await c.req.json().catch(() => null))
+    if (!bodyResult.success) {
+      return c.json({ error: bodyResult.error.issues[0]?.message ?? 'Datos inválidos' }, 422)
+    }
+
+    const db = createDb(c.env.DB)
+    const user = await createUser(db, bodyResult.data)
+    return c.json({ data: user }, 201)
+  }
+}
+
+export class UsersUpdate extends OpenAPIRoute {
+  schema = {
+    tags: ['Users'],
+    summary: 'Update user',
+    security: [{ ApiKeyAuth: [] }],
+    request: {
+      params: UserIdParamSchema,
+      body: { content: { 'application/json': { schema: UpdateUserSchema } } },
+    },
+    responses: {
+      200: { description: 'OK', content: { 'application/json': { schema: UserResponse } } },
+      400: { description: 'Invalid ID', content: { 'application/json': { schema: ErrorResponse } } },
+      404: { description: 'Not found', content: { 'application/json': { schema: ErrorResponse } } },
+      422: { description: 'Validation error', content: { 'application/json': { schema: ErrorResponse } } },
+    },
+  } as any
+
+  async handle(c: AppCtx) {
+    const paramsResult = UserIdParamSchema.safeParse(c.req.param())
+    if (!paramsResult.success) {
+      return c.json({ error: paramsResult.error.issues[0]?.message ?? 'ID inválido' }, 400)
+    }
+
+    const bodyResult = UpdateUserSchema.safeParse(await c.req.json().catch(() => null))
+    if (!bodyResult.success) {
+      return c.json({ error: bodyResult.error.issues[0]?.message ?? 'Datos inválidos' }, 422)
+    }
+
+    const db = createDb(c.env.DB)
+    const user = await updateUser(db, paramsResult.data.id, bodyResult.data)
+    if (!user) return c.json({ error: 'Usuario no encontrado' }, 404)
+
+    return c.json({ data: user })
+  }
+}
+
+export class UsersDelete extends OpenAPIRoute {
+  schema = {
+    tags: ['Users'],
+    summary: 'Delete user',
+    security: [{ ApiKeyAuth: [] }],
+    request: { params: UserIdParamSchema },
+    responses: {
+      200: { description: 'OK', content: { 'application/json': { schema: DeleteResponse } } },
+      400: { description: 'Invalid ID', content: { 'application/json': { schema: ErrorResponse } } },
+      404: { description: 'Not found', content: { 'application/json': { schema: ErrorResponse } } },
+    },
+  } as any
+
+  async handle(c: AppCtx) {
+    const paramsResult = UserIdParamSchema.safeParse(c.req.param())
+    if (!paramsResult.success) {
+      return c.json({ error: paramsResult.error.issues[0]?.message ?? 'ID inválido' }, 400)
+    }
+
+    const db = createDb(c.env.DB)
+    const deleted = await deleteUser(db, paramsResult.data.id)
+    if (!deleted) return c.json({ error: 'Usuario no encontrado' }, 404)
+
+    return c.json({ message: 'Usuario eliminado' })
+  }
+}

--- a/src/schemas/users.schema.ts
+++ b/src/schemas/users.schema.ts
@@ -1,0 +1,22 @@
+import { z } from 'zod'
+
+export const UserSchema = z.object({
+  id: z.number().int(),
+  name: z.string(),
+  email: z.string().email(),
+  created_at: z.string(),
+})
+
+export const CreateUserSchema = z.object({
+  name: z.string().trim().min(1).max(100),
+  email: z.string().email().max(200),
+})
+
+export const UpdateUserSchema = z.object({
+  name: z.string().trim().min(1).max(100).optional(),
+  email: z.string().email().max(200).optional(),
+})
+
+export const UserIdParamSchema = z.object({
+  id: z.coerce.number().int().positive(),
+})


### PR DESCRIPTION
## Summary
- add full CRUD for the users resource on top of the v2 Drizzle + Zod + Chanfana stack
- register the new OpenAPI routes in src/index.ts so users follows the same layered architecture as items and categories
- add dedicated CRUD tests for users, including email validation and normalization

## Test plan
- [x] docker compose --profile test run --rm test npm run typecheck
- [x] docker compose --profile test run --rm test npm test
- [x] docker compose --profile test run --rm test npm run lint

Related to #16